### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   node: circleci/node@5.1.0
 jobs:
-  clone-and-install:
+  build-and-test:
     docker:
      - image: cimg/node:12.13.1
     steps:
@@ -10,14 +10,11 @@ jobs:
       - node/install-yarn:
         version: 1.22.21
       - node/install-packages:
-          pkg-manager: yarn 
+          pkg-manager: yarn
+      - run: yarn build
+      - run: yarn build:demo
+      - run: yarn coverage
 workflows:
   build-and-test:
     jobs:
-      - clone-and-install
-      - node/run:
-        yarn-run: build
-      - node/run:
-        yarn-run: build:demo
-      - node/run:
-        yarn-run: coverage
+      - build-and-test


### PR DESCRIPTION
The Node orb Job is not working, Replace it with the old style of running all the command within one job.

Multiple jobs will not work for our project as each job will try to clone again and install dependencies.
https://app.circleci.com/pipelines/github/evolvedbinary/prosemirror-jdita/9/workflows/3a83edc3-bd61-4ec1-b203-e1093b67a3d8 
this run for example.

